### PR TITLE
Everything inherits from plexsync.base to improve config/logging

### DIFF
--- a/app.py
+++ b/app.py
@@ -118,7 +118,7 @@ def transfer():
             theirServer = plexsync.getServer(server)
             section = theirServer.library.sectionByID(section)
             result = section.search(guid=guid).pop()
-        if authorized: 
+        if authorized:
             plexsync.transfer(result)
             msg = f"Transferring {result.title} to {currentUserServer}"
             return json.dumps(msg)
@@ -129,40 +129,36 @@ def transfer():
     except Exception as e:
         return json.dumps(str(e))
 
-
-
 @app.route('/compare/<string:yourServerName>/<string:theirServerName>', methods=['GET'])
 @app.route('/compare/<string:yourServerName>/<string:theirServerName>/<string:sectionName>', methods=['GET'])
 def compare(yourServerName, theirServerName, sectionName=None):
-    
-    plexsync = PlexSync()
-    plexAccount = plexsync.getAccount(session['username'], session['password'])
-    sectionsToCompare = []
+    try:
+        plexsync = PlexSync()
+        plexAccount = plexsync.getAccount(session['username'], session['password'])
+        sectionsToCompare = []
 
-    if not sectionName:    
-        settings = plexsync.getSettings()
-        sectionsToCompare = settings.get('sections', 'sections').split(",")
-    else:
-        sectionsToCompare.append(sectionName)
+        if not sectionName:
+            settings = plexsync.getSettings()
+            sectionsToCompare = settings.get('sections', 'sections').split(",")
+        else:
+            sectionsToCompare.append(sectionName)
 
-    yourServer = plexsync.getServer(yourServerName)
-    session['yourServer'] = yourServerName
-    theirServer = plexsync.getServer(theirServerName)
-    
-    for section in sectionsToCompare:
-        yourLibrary = plexsync.getResults(yourServer, section)
-        theirLibrary = plexsync.getResults(theirServer, section)
-        results = plexsync.compareLibrariesAsResults(yourLibrary, theirLibrary)
+        yourServer = plexsync.getServer(yourServerName)
+        session['yourServer'] = yourServerName
+        theirServer = plexsync.getServer(theirServerName)
 
-        print(f"{section} {len(yourLibrary)} in yours {len(theirLibrary)} in theirs")
-        print(f"{len(results)} your diff")
-        result_list = []
-        for r in results:
-                app.logger.debug("in compare")
+        for section in sectionsToCompare:
+            yourLibrary = plexsync.getResults(yourServer, section)
+            theirLibrary = plexsync.getResults(theirServer, section)
+            results = plexsync.compareLibrariesAsResults(yourLibrary, theirLibrary)
 
-                app.logger.debug(r)
+            app.logger.debug(f"{section} {len(yourLibrary)} in yours {len(theirLibrary)} in theirs")
+            app.logger.debug(f"{len(results)} your diff")
+            result_list = []
+
+            for r in results:
+
                 m = plexsync.getAPIObject(r)
-                app.logger.debug(m)
 
                 result_dict = {}
                 result_dict['title'] = m.title
@@ -176,11 +172,13 @@ def compare(yourServerName, theirServerName, sectionName=None):
                     result_dict['image'] = m.image
                 result_dict['rating'] = m.rating
                 result_list.append(result_dict)
-        return render_template('media.html', media=result_list)
+    except Exception as e:
+          return json.dumps(str(e))
+    return render_template('media.html', media=result_list)
 
 @app.route('/compareResults/<string:yourServerName>/<string:theirServerName>/<string:sectionName>', methods=['GET'])
 def compareResults(yourServerName, theirServerName, sectionName=None):
-    
+
     plexsync = PlexSync()
     plexAccount = plexsync.getAccount(session['username'], session['password'])
     sectionsToCompare = []

--- a/plexsync/plexsync/addoptions.py
+++ b/plexsync/plexsync/addoptions.py
@@ -8,25 +8,23 @@ from plexsync.setting import *
 from plexsync.thirdparty import *
 from plexsync.thirdpartyservice import *
 
-base = Base()
-settings = base.getSettings()
-
 #ignoreWithFiles: Unmonitors any episodes with a file
 #ignoreWithoutFiles: Unmonitors any episodes without a file
 #searchForMissing: Searches for missing files after applying ignoreWithFiles and ignoreWithoutFiles
 #searchForMovie: Radarr specific
 
-class AddOptions():
+class AddOptions(Base):
     def __init__(self, service):
+            super().__init__()
             self.service = service
             try:
-                self.ignoreWithFiles = settings.getboolean(service.value, 'ignore_with_files')
+                self.ignoreWithFiles = self.settings.getboolean(service.value, 'ignore_with_files')
             except configparser.NoOptionError:
                 promptString = str(f"Should {service.value} ignore items with files?")
                 theSetting = Setting("ignore_with_files", service.value, promptString)
                 self.ignoreWithFiles = theSetting.write() 
             try:
-                self.ignoreWithoutFiles = settings.getboolean(service.value, 'ignore_without_files')
+                self.ignoreWithoutFiles = self.settings.getboolean(service.value, 'ignore_without_files')
             except configparser.NoOptionError:
                 promptString = str(f"Should {service.value} ignore items without files?")
                 theSetting = Setting("ignore_without_files", service.value, promptString)
@@ -34,9 +32,9 @@ class AddOptions():
 
             try:
                 if self.service == ThirdPartyService.Show:
-                    self.searchForMissingEpisodes = settings.getboolean(service.value, 'search_for_missing')
+                    self.searchForMissingEpisodes = self.settings.getboolean(service.value, 'search_for_missing')
                 elif self.service == ThirdPartyService.Movie:
-                    self.searchForMovie = settings.getboolean(service.value, 'search_for_missing')
+                    self.searchForMovie = self.settings.getboolean(service.value, 'search_for_missing')
             except configparser.NoOptionError:
                 promptString = str(f"Should {service.value} automatically search when items are added?")
                 theSetting = Setting("search_for_missing", service.value, promptString)

--- a/plexsync/plexsync/apiobject.py
+++ b/plexsync/plexsync/apiobject.py
@@ -42,11 +42,19 @@ class APIObject(Video):
             self.overview = video.summary
             self.rating = video.rating
             self.year = video.year
+            #plex api doesn't support poster directly, just the banner, but it's a plex structured url, so swap it.
+            if video.banner is None:
+              self.log.debug(f"no banner: Falling back to {video.artUrl}")
+              self.image= video.artUrl
+            else:
+              self.log.debug(f"Switching banner to poster {video.banner}")
+              self.image =  video.url(video.banner).replace("banner", "poster")
         elif video.type == "movie":
             self.title = video.title
             self.type = APIObjectType.Movie
             self.provider = movie_provider
             self.guid = video.guid
+            self.image = video.artUrl
         else:
             self.log.debug(f"Unable to determine Object Type for {video}")
             return None
@@ -56,14 +64,7 @@ class APIObject(Video):
         self.seasons = []
         self.librarySectionID = video.librarySectionID
         self.downloadURL = self._getDownloadURL(video)
-        #plex api doesn't support poster directly, just the banner, but it's a plex structured url, so swap it.
-        if video.banner is None:
-           self.log.debug(f"no banner: Falling back to {video.artUrl}")
-           self.image= video.artUrl
-        else:
-           self.log.debug(f"Switching banner to poster {video.banner}")
-           self.image =  video.url(video.banner).replace("banner", "poster")
-
+      
     def isMovie(self):
         return self.type == APIObjectType.Movie
 

--- a/plexsync/plexsync/base.py
+++ b/plexsync/plexsync/base.py
@@ -1,7 +1,10 @@
+
 import configparser
 import enum
+import logging
 import os
 import sys
+
 
 from pathlib import Path
 
@@ -13,17 +16,24 @@ def dump(obj):
             print("obj.%s = %s" % (attr, getattr(obj, attr)))
 
 class Base:
+    def __init__(self):
+        self.log = logging.getLogger("plexsync")
+        self.settings = self.getSettings() 
+
     def getSettings(self):
-        settings = configparser.ConfigParser()
-        print(f"Reading configuration from {CONFIG_PATH} ")
-        settings.read(CONFIG_PATH)
-        return settings
+          config = configparser.SafeConfigParser()
+          self.log.info(f"Reading configuration from {CONFIG_PATH}")
+          config.read(CONFIG_PATH)  
+          return config
 
-    def writeSettings(settings):
+    def writeSettings(self,settings):
         with open(CONFIG_PATH, 'w') as config_file:
-            settings.write(config_file)
+            self.settings.write(config_file)
 
-
+    def create_dir(self, directory):
+        if not os.path.exists(directory):
+          self.log.info(f"Creating {directory}")
+          os.makedirs(directory) 
 
 #Create a module level instance of settings
 

--- a/plexsync/plexsync/thirdparty.py
+++ b/plexsync/plexsync/thirdparty.py
@@ -12,27 +12,23 @@ from plexsync.thirdpartyservice import *
 
 from pick import pick
 
-base = Base()
-
-settings = base.getSettings()
-
-class ThirdParty():
+class ThirdParty(Base):
     def __init__(self, service):
-        self.log = logging.getLogger('plexsync')
+        super().__init__()
         self.service = service
         self.qualityProfiles = None #Set quality profiles so the real getter can cache them
         self.addOptions = AddOptions(self.service)
         try:
-            self.host = settings.get(service.value, 'host')
+            self.host = self.settings.get(service.value, 'host')
             self.apiRoot = "api"
             self.endpointBase = f"{self.host}/{self.apiRoot}/"
             self.endpoints = {"lookup": None, "profile" : "profile", "rootfolder" : "rootfolder" }
-            self.apiKey = settings.get(service.value, 'api-key')
+            self.apiKey = self.settings.get(service.value, 'api-key')
             self.headers = {'X-Api-Key': self.apiKey}
             self.rootFolder = self._getRootfolder()
 
             try:
-                self.qualityProfile = settings.get(service.value, 'quality_profile')
+                self.qualityProfile = self.settings.get(service.value, 'quality_profile')
             except configparser.NoOptionError:
                 self.qualityProfile = self.setQualityProfileSetting()
             if self.service == ThirdPartyService.Show:


### PR DESCRIPTION
fixes #25 

Objects have access to the plexsync logging stream without having to fetch it themselves.
Don't have to keep rereading the config file repeatedly